### PR TITLE
RSDK-8017: added golangci-lint to docker image

### DIFF
--- a/etc/Dockerfile.debian.bookworm
+++ b/etc/Dockerfile.debian.bookworm
@@ -125,4 +125,7 @@ RUN cd /root/opt/src && \
 # install appimage-builder
 RUN pip3 install --break-system-packages git+https://github.com/AppImageCrafters/appimage-builder.git@61c8ddde9ef44b85d7444bbe79d80b44a6a5576d
 
+# golangci-lint installation here
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.53.2
+
 ENV PATH="/usr/local/go/bin:${PATH}"


### PR DESCRIPTION
Updated docker image to have golangci-lint. Built and pushed this image. 