### PR TITLE
RSDK-8017: updated golangci-lint version in docker img

### DIFF
--- a/etc/Dockerfile.debian.bookworm
+++ b/etc/Dockerfile.debian.bookworm
@@ -126,6 +126,6 @@ RUN cd /root/opt/src && \
 RUN pip3 install --break-system-packages git+https://github.com/AppImageCrafters/appimage-builder.git@61c8ddde9ef44b85d7444bbe79d80b44a6a5576d
 
 # golangci-lint installation here
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.53.2
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.59.1
 
 ENV PATH="/usr/local/go/bin:${PATH}"


### PR DESCRIPTION
Changed the version of golangci-lint to be the most recent one