### PR TITLE
Replace defunct buildjet runners with GitHub-hosted runners

### DIFF
--- a/.github/workflows/build-arm64-module.yml
+++ b/.github/workflows/build-arm64-module.yml
@@ -35,7 +35,7 @@ jobs:
   publish:
     needs: validate-tag
     name: Upload module for linux/arm64
-    runs-on: [buildjet-2vcpu-ubuntu-2204-arm]
+    runs-on: [github-linux-arm64-8core]
     container:
       image: ghcr.io/viamrobotics/ocean-prefilter:arm64
       options: --platform linux/arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: "Run unit tests"
-    runs-on: [buildjet-2vcpu-ubuntu-2204-arm]
+    runs-on: [github-linux-arm64-8core]
     container:
       image: ghcr.io/viamrobotics/ocean-prefilter:arm64
       options: --platform linux/arm64


### PR DESCRIPTION
The buildjet runners no longer work, breaking these workflows. This maps them to GitHub-hosted runners, matching the fix already made in [viamrobotics/rust-utils#178](https://github.com/viamrobotics/rust-utils/pull/178):

- `buildjet-*-ubuntu-2204-arm` (native arm64 builds) -> `github-linux-arm64-8core`
- `buildjet-*-ubuntu-2204` (x86) -> `ubuntu-large`

These are all native per-arch builds (arm64 container images / `--platform linux/arm64`), so the arm jobs map to the arm GitHub runner. Where present, the now-unused buildjet labels are also dropped from `.github/actionlint.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)