### PR TITLE
update linter and add docker build action

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,46 @@
+name: publish base images
+
+on:
+  workflow_dispatch
+
+jobs:
+  build-and-push-image:
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            tag: amd64
+          - runs-on: ubuntu-4cpu-arm
+            tag: arm64
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ matrix.tag }}
+      - id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,7 +1,11 @@
 name: publish base images
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      push:
+        type: boolean
+        description: if false, this will run a test build but not push it to ghcr.io
 
 jobs:
   build-and-push-image:
@@ -29,13 +33,12 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=${{ matrix.tag }}
+          tags: type=raw,value=${{ matrix.tag }}
       - id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
-          push: true
+          push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Generate artifact attestation
@@ -43,4 +46,4 @@ jobs:
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          push-to-registry: ${{ inputs.push }}

--- a/etc/Dockerfile.debian.bookworm
+++ b/etc/Dockerfile.debian.bookworm
@@ -125,7 +125,6 @@ RUN cd /root/opt/src && \
 # install appimage-builder
 RUN pip3 install --break-system-packages git+https://github.com/AppImageCrafters/appimage-builder.git@61c8ddde9ef44b85d7444bbe79d80b44a6a5576d
 
-# golangci-lint installation here
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.59.1
+RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s v2.12.2
 
 ENV PATH="/usr/local/go/bin:${PATH}"


### PR DESCRIPTION
## What changed
- update the pinned golangci-lint in the dockerfile
- add a yaml workflow to release the docker images (convenience improvement)
## Why
See [failed build](https://github.com/viamrobotics/ocean-prefilter/actions/runs/27787376046/job/82246608343#step:5:6):
> level=warning msg="[runner] Can't run linter goanalysis_metalinter: buildir: failed to load package goarch: could not load export data: internal error in importing \"internal/goarch\" (unsupported version: 2); please report an issue"

Updating the linter fixes this on my local machine.