### PR TITLE
fix ARCH_TAG so module/AppImage builds find the right recipe

### DIFF
--- a/.github/workflows/build-amd64-module.yml
+++ b/.github/workflows/build-amd64-module.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Build
-        run: make module.tar.gz
+        run: make module.tar.gz ARCH_TAG=amd64
       - name: Upload
         uses: viamrobotics/upload-module@v1
         with:

--- a/.github/workflows/build-arm64-module.yml
+++ b/.github/workflows/build-arm64-module.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Build
-        run: make module.tar.gz
+        run: make module.tar.gz ARCH_TAG=arm64
       - name: Upload
         uses: viamrobotics/upload-module@v1
         with:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           context: .
           file: etc/Dockerfile.debian.bookworm
+          build-args: |
+            BASE_TAG=${{ matrix.tag }}
           push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,15 @@ if ! command -v docker &> /dev/null; then
     exit 1
 fi
 
-# check the architecture
-ARCH=$(uname -m)
+# check the architecture and normalize to the tags used by the Makefile and image registry
+case "$(uname -m)" in
+    x86_64)  ARCH=amd64 ;;
+    aarch64) ARCH=arm64 ;;
+    *)
+        echo "Unsupported architecture: $(uname -m). Expected x86_64 or aarch64."
+        exit 1
+        ;;
+esac
 
 # pull the Docker image and log in
 DOCKER_IMAGE="ghcr.io/viamrobotics/ocean-prefilter:$ARCH"


### PR DESCRIPTION
## Summary

Fixes the release pipeline so `viam module` AppImage builds resolve the correct
AppImage recipe per architecture.

## Root cause

The Makefile selects the AppImage recipe from `ARCH_TAG`
(`arm64 → aarch64`, `amd64 → x86_64`, else → `none`). The only recipes that
exist are `ocean-prefilter-aarch64.yml` and `ocean-prefilter-x86_64.yml`, so a
`none` value can never resolve.

`ARCH_TAG` was meant to be baked into the build container via the Dockerfile's
`ENV ARCH_TAG=$BASE_TAG`, but `build-docker.yml` rebuilt the base images
**without passing the `BASE_TAG` build-arg**. Since the Dockerfile defaults
`ARG BASE_TAG=none`, the new images shipped with `ARCH_TAG` effectively unset,
so every release build fell through to the `none` recipe.

## Changes

- **`.github/workflows/build-arm64-module.yml`** / **`build-amd64-module.yml`** —
  pass `ARCH_TAG` explicitly to `make module.tar.gz` so the release build no
  longer depends on the container's baked-in environment.
- **`.github/workflows/build-docker.yml`** — pass `build-args: BASE_TAG=<tag>`
  so the base images bake in the correct `ARCH_TAG` again (fixes the root cause).
- **`build.sh`** — map `uname -m` (`x86_64`/`aarch64`) to the `amd64`/`arm64`
  tags the Makefile and image registry expect. Previously it passed the raw
  `uname -m` value (also resolving to `none`) and pulled a non-existent
  `ghcr.io/...:<uname>` image tag, breaking the local / `viam module build` path.

## Follow-up

After merge, run the **publish base images** workflow once with `push=true`
(`gh workflow run "publish base images" -f push=true`) to refresh the base
images with the corrected `ARCH_TAG`. The release workflows are self-sufficient
(they pass `ARCH_TAG` directly), so a new tag will build green even before the
images are refreshed.
